### PR TITLE
Fix for incorrect class for styling navtext

### DIFF
--- a/examples/Styled/StyledSideNav.jsx
+++ b/examples/Styled/StyledSideNav.jsx
@@ -67,7 +67,7 @@ const StyledNav = styled(Nav)`
                     color: #666;
                 }
             }
-            [class*="sidenav-nav-text--"] {
+            [class*="navtext--"] {
                 &, > * {
                     color: #222;
                 }
@@ -82,10 +82,8 @@ const StyledNav = styled(Nav)`
             [class*="navtext--"] {
                 &, > * {
                     color: #db3d44;
+                    font-weight: 700;
                 }
-            }
-            [class*="sidenav-nav-text--"] {
-                font-weight: 700;
             }
         }
     }


### PR DESCRIPTION
For the styled nav example, the classes for modifying the `navtext` were incorrect.  They had no effect in modifying the color of the font-weight.  They will now correctly change the color and make the font bold in the example.